### PR TITLE
Delete fs directory after compression

### DIFF
--- a/handlers/filesystem.go
+++ b/handlers/filesystem.go
@@ -158,7 +158,17 @@ func (h *FileSystemHandler) Backup(ctx context.Context) (string, error) {
 	}
 
 	// Create archive
-	return h.createArchive()
+	archivePath, err := h.createArchive()
+	if err != nil {
+		return "", err
+	}
+
+	// Delete the fs directory after creating the tarfile
+	if err := h.deleteDirectory(); err != nil {
+		return "", err
+	}
+
+	return archivePath, nil
 }
 
 // Name returns the handler name
@@ -172,6 +182,14 @@ func (h *FileSystemHandler) Cleanup() error {
 		if err := os.RemoveAll(h.tempDir); err != nil {
 			return &ErrFileSystem{Op: "cleanup", Err: err}
 		}
+	}
+	return nil
+}
+
+// deleteDirectory deletes the fs directory
+func (h *FileSystemHandler) deleteDirectory() error {
+	if err := os.RemoveAll(config.Cfg.Filesystem.BasePath); err != nil {
+		return &ErrFileSystem{Op: "delete directory", Err: err}
 	}
 	return nil
 }

--- a/sentinel/main.go
+++ b/sentinel/main.go
@@ -155,6 +155,11 @@ func performBackup(handlerList []handlers.BackupHandler, uploader *storage.S3Upl
 		return err
 	}
 
+	// Delete the fs directory after creating the tarfile
+	if err := deleteDirectory(); err != nil {
+		return err
+	}
+
 	// Cleanup
 	for _, file := range backupFiles {
 		err := os.Remove(file)
@@ -167,5 +172,13 @@ func performBackup(handlerList []handlers.BackupHandler, uploader *storage.S3Upl
 		log.Printf("Failed to remove temporary backup directory: %v", err)
 	}
 
+	return nil
+}
+
+// deleteDirectory deletes the fs directory
+func deleteDirectory() error {
+	if err := os.RemoveAll(config.Cfg.Filesystem.BasePath); err != nil {
+		return fmt.Errorf("failed to delete directory: %v", err)
+	}
 	return nil
 }


### PR DESCRIPTION
Delete the `fs` directory after converting to a tarfile to reduce space costs.

* Add a function `deleteDirectory` in `handlers/filesystem.go` to delete the `fs` directory after creating the tarfile.
* Call `deleteDirectory` in the `Backup` function in `handlers/filesystem.go` after creating the tarfile.
* Add a call to `deleteDirectory` in `performBackup` in `sentinel/main.go` after the tarfile is created.
* Add a function `deleteDirectory` in `sentinel/main.go` to delete the `fs` directory.

